### PR TITLE
Reset test data between concurrency specs

### DIFF
--- a/src/spec/use_cases/transactions/authorize_transaction_concurrency_spec.rb
+++ b/src/spec/use_cases/transactions/authorize_transaction_concurrency_spec.rb
@@ -9,23 +9,17 @@ RSpec.describe UseCases::Transactions::AuthorizeTransaction, type: :model do
   let(:merchant) { create_merchant }
   let(:credit_account) { create_credit_account(user:, credit_limit: 1000, available_credit: 1000) }
 
+  before(:each) do
+    clean_database
+  end
+
   before do
     # Ensure credit account exists and is in correct state
     credit_account
   end
 
   after(:all) do
-    # Clean up test data after all examples
-    # Delete order must respect foreign key constraints:
-    # - LedgerEntry references Transaction (ON DELETE RESTRICT)
-    # - CreditAccount references User (ON DELETE RESTRICT)
-    # Delete LedgerEntry BEFORE Transaction to avoid FK constraint violation
-    LedgerEntry.delete_all
-    Transaction.delete_all
-    AuditLog.delete_all
-    CreditAccount.delete_all
-    Merchant.delete_all
-    User.delete_all
+    clean_database
   end
 
   describe 'when concurrent authorization exceeds credit limit' do
@@ -298,6 +292,20 @@ RSpec.describe UseCases::Transactions::AuthorizeTransaction, type: :model do
       available_credit:,
       status: 'ACTIVE'
     )
+  end
+
+  def clean_database
+    # Clean up test data
+    # Delete order must respect foreign key constraints:
+    # - LedgerEntry references Transaction (ON DELETE RESTRICT)
+    # - CreditAccount references User (ON DELETE RESTRICT)
+    # Delete LedgerEntry BEFORE Transaction to avoid FK constraint violation
+    LedgerEntry.delete_all
+    Transaction.delete_all
+    AuditLog.delete_all
+    CreditAccount.delete_all
+    Merchant.delete_all
+    User.delete_all
   end
 end
 


### PR DESCRIPTION
## Summary
- clean the concurrency spec database tables before each example to isolate state
- reuse the same cleanup helper in the existing after-all hook

## Testing
- Not run (rspec dependencies not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694808cc072083269f0ed31b936b9726)